### PR TITLE
updated time synchronization server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ apparmor_level: "enforce"     # Set all profiles in /etc/apparmor.d/* to this le
 time_service: "chrony"          # Linux: Option for RHEL7/Ubuntu only. RHEL8 only ships with chrony and this variable is not used
                                 # Linux: Choices are 'ntp' or chrony'. For Ubuntu, this can also accept 'none' as an option to use only systemd timedatectl
 ##time_server: "2.rhel.pool.ntp.org" # Linux: Time server for ntp, chrony, or timedatectl
-time_server: "10.0.0.2"
+time_server: "169.254.169.123"
 time_operators:                 # Windows: Users that can set the system time
   - "Administrators"
   - "LOCAL SERVICE"

--- a/templates/chrony.conf
+++ b/templates/chrony.conf
@@ -1,6 +1,6 @@
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
-pool {{ time_server }} iburst
+pool {{ time_server }} prefer iburst minpoll 4 maxpoll 4
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/ntp.conf
+++ b/templates/ntp.conf
@@ -1,6 +1,6 @@
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
-pool {{ time_server }} iburst
+pool {{ time_server }} prefer iburst minpoll 4 maxpoll 4
 
 restrict -4 default kod nomodify notrap nopeer noquery 
 


### PR DESCRIPTION
Chronyd time synchronization servers was updated to 169.254.169.123, this is the amazon time server for all hosts inside amazon vpc. Rhel8 worked perfectly with no issue with all the sectools after this update.